### PR TITLE
Add braces to all outgoing requests so that Prefixr behaves itself...

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -46,5 +46,9 @@
             "file": "${packages}/User/Default (Linux).sublime-keymap",
             "platform": "Linux"
         }
+    },
+    {
+        "caption": "Prefixr",
+        "command": "prefixr"
     }
 ]

--- a/Prefixr.py
+++ b/Prefixr.py
@@ -167,12 +167,12 @@ class PrefixrApiCall(threading.Thread):
 
     def run(self):
         try:
-            data = urlencode({'css': self.original})
+            data = urlencode({'css': '{%s}' % (self.original)})
             data = data.encode('utf8')
             request = Request('http://prefixr.com/api/index.php', data,
                 headers={"User-Agent": "Sublime Prefixr"})
             http_file = urlopen(request, timeout=self.timeout)
-            self.result = http_file.read()
+            self.result = http_file.read().replace('{', '').replace('}', '')
             return
 
         except (HTTPError) as e:

--- a/Prefixr.py
+++ b/Prefixr.py
@@ -152,11 +152,11 @@ class PrefixrApiCall(threading.Thread):
 
     def run(self):
         try:
-            data = urllib.urlencode({'css': self.original})
+            data = urllib.urlencode({'css': '{%s}' % (self.original)})
             request = urllib2.Request('http://prefixr.com/api/index.php', data,
                 headers={"User-Agent": "Sublime Prefixr"})
             http_file = urllib2.urlopen(request, timeout=self.timeout)
-            self.result = http_file.read()
+            self.result = http_file.read().replace('{', '').replace('}', '')
             return
 
         except (urllib2.HTTPError) as (e):


### PR DESCRIPTION
Adds brackets around all styles before sending them to the Prefixr api.

Prefixr has a bug that occasionally clobbers any styles preceeding the
ones being prefixed.  Until that gets fixed, this patch should allow the
plugin to work correctly...

Fixes #2 and #4
